### PR TITLE
Force install nvm v0.39

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -94,7 +94,9 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
-          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+          # echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+          # Install nvm v0.39 (workaround for https://github.com/moodlehq/moodle-plugin-ci/issues/309).
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 
       - name: Install tool plugin
         if: ${{ inputs.requires-tool-plugin == true }}


### PR DESCRIPTION
This PR fixes #5 temporary by forcing the installation of `nvm` v0.39.
This should be changed when there is an upstream fix in moodlehq/moodle-plugin-ci